### PR TITLE
Add RedHat to distributions for enabling all repos 

### DIFF
--- a/server_register_via_api.yml
+++ b/server_register_via_api.yml
@@ -160,7 +160,7 @@
 
     - name: Enable all repositories
       when:
-        - "ansible_distribution == 'CentOS'"
+        - ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
         - "ansible_distribution_major_version | int  == 7"
       ansible.builtin.command: |
         yum-config-manager --enable \*


### PR DESCRIPTION
Add RedHat to distributions for enabling all repos  after system registration.