### PR TITLE
C2R: Remove env vars/opts with no effect

### DIFF
--- a/c2r_analysis.yml
+++ b/c2r_analysis.yml
@@ -5,9 +5,12 @@
   gather_facts: true
   become: true
   environment:
-    CONVERT2RHEL_DISABLE_TELEMETRY: 1
-    # CONVERT2RHEL_ALLOW_OLDER_VERSION: 1
-    # CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK: 1
+    # The CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP and CONVERT2RHEL_ALLOW_OLDER_VERSION
+    # variables are needed when an older version of convert2rhel is used. The
+    # package-up-to-date and convert2rhel-latest-version checks inhibit the
+    # conversion if not passing but can be overriden.
+    CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP: 1
+    CONVERT2RHEL_ALLOW_OLDER_VERSION: 1
   vars:
     rhsm_username: ""
     rhsm_password: ""

--- a/c2r_convert.yml
+++ b/c2r_convert.yml
@@ -5,10 +5,7 @@
   gather_facts: true
   become: true
   environment:
-    CONVERT2RHEL_DISABLE_TELEMETRY: 1
-    # CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK: 1
     CONVERT2RHEL_INCOMPLETE_ROLLBACK: 1
-    CONVERT2RHEL_LATEST_VERSION: 0
   vars:
     rhsm_username: ""
     rhsm_password: ""

--- a/group_vars/control/worflow_job_templates.yml
+++ b/group_vars/control/worflow_job_templates.yml
@@ -4,8 +4,7 @@ controller_workflows:
     description: Workflow for Snapshot and Pre-conversion analysis of EL systems
     extra_vars:
       org_id: "Default_Organization"
-      convert_convert2rhel_opts: '--no-rpm-va'
-      convert_reboot_requested: true
+      convert_convert2rhel_opts: ''
       lvm_snapshots_action: create
     inventory: EC2 Dynamic Inventory
     state: present


### PR DESCRIPTION
- The --no-rpm-va option has no effect with `convert2rhel analysis` anymore (rpm -Va runs always and a warning is printed when the option is used saying that it has no effect) -- Related: https://github.com/oamg/convert2rhel/pull/875
- The CONVERT2RHEL_DISABLE_TELEMETRY env var was removed -- Related: https://github.com/oamg/convert2rhel/pull/1102
- The CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK was removed in favor of CONVERT2RHEL_INCOMPLETE_ROLLBACK -- Related: https://github.com/oamg/convert2rhel/pull/1147
- The CONVERT2RHEL_LATEST_VERSION env var has never been a valid env var recognized by convert2rhel. It is an ID of one of convert2rhel Actions. A similar env var to this is CONVERT2RHEL_UNSUPPORTED_VERSION which is in recent versions (2.x) removed in favor of CONVERT2RHEL_ALLOW_OLDER_VERSION.

Also, the `convert_reboot_requested` should not be needed when it comes to just analyzing the system (`convert2rhel analyze`). The `--restart` convert2rhel option is heeded just when it comes to the actual conversion.

And, when the workshop executes and older convert2rhel version (on
purpose) then the pre-conversion analysis ends up with two inhibitors:
- Outdated convert2rhel version detected
- Outdated packages detected

This PR adds the related environment variables to override the inhibitors.